### PR TITLE
Add scan implementation with Agency

### DIFF
--- a/cmake/SetupPackages.cmake
+++ b/cmake/SetupPackages.cmake
@@ -67,7 +67,7 @@ if (RAJA_ENABLE_AGENCY)
       SET(AGENCY_INCLUDE_DIR ${AGENCY_CLONE_DIR})
     endif()
   endif()
-  include_directories(${AGENCY_INCLUDE_DIR})
+  include_directories(SYSTEM ${AGENCY_INCLUDE_DIR})
 endif()
 
 if (RAJA_ENABLE_CUDA)

--- a/include/RAJA/exec-agency/raja_agency.hxx
+++ b/include/RAJA/exec-agency/raja_agency.hxx
@@ -112,9 +112,11 @@ struct agency_reduce { };
 }  // closing brace for RAJA namespace
 
 #include "RAJA/exec-agency/forall_agency.hxx"
-// TODO: Implement reduce, scan, forallN
+
+// TODO: Implement reduce
 // #include "RAJA/exec-agency/reduce_agency.hxx"
-// #include "RAJA/exec-agency/scan_agency.hxx"
+#include "RAJA/exec-agency/scan_agency.hxx"
+ 
 // 
 // #if defined(RAJA_ENABLE_NESTED)
 // #include "RAJA/exec-agency/forallN_agency.hxx"

--- a/include/RAJA/exec-agency/scan_agency.hxx
+++ b/include/RAJA/exec-agency/scan_agency.hxx
@@ -107,7 +107,7 @@ void inclusive_inplace(const ::RAJA::agency_base<agency::parallel_agent, Worker>
                               exclusive_inplace(
                                   ::RAJA::seq_exec{}, sumsP, sumsP + p, f, BinFn::identity);
                           }
-                          // self.wait();
+                          self.wait();
 
                           for (int i = i0; i < i1; ++i) {
                               *(begin + i) = f(*(begin + i), sumsP[pid]);
@@ -154,7 +154,7 @@ void exclusive_inplace(const ::RAJA::agency_base<agency::parallel_agent, Worker>
                               exclusive_inplace(
                                   ::RAJA::seq_exec{}, sumsP, sumsP + p, f, BinFn::identity);
                           }
-                          // self.wait()
+                          self.wait();
 
                           for (int i = i0; i < i1; ++i) {
                               *(begin + i) = f(*(begin + i), sumsP[pid]);

--- a/include/RAJA/exec-sequential/scan_sequential.hxx
+++ b/include/RAJA/exec-sequential/scan_sequential.hxx
@@ -69,6 +69,12 @@ namespace detail
 namespace scan
 {
 
+RAJA_INLINE
+int firstIndex(int n, int p, int pid)
+{
+  return static_cast<size_t>(n * pid) / p;
+}
+
 /*!
         \brief explicit inclusive inplace scan given range, function, and
    initial value

--- a/include/RAJA/operators.hxx
+++ b/include/RAJA/operators.hxx
@@ -260,7 +260,7 @@ RAJA_HOST_DEVICE constexpr T max()
 template <typename Ret, typename Arg1 = Ret, typename Arg2 = Arg1>
 struct plus : public detail::binary_function<Arg1, Arg2, Ret>,
               detail::associative_tag {
-  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs)
+  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs) const
   {
     return Ret{lhs} + rhs;
   }
@@ -269,7 +269,7 @@ struct plus : public detail::binary_function<Arg1, Arg2, Ret>,
 
 template <typename Ret, typename Arg1 = Ret, typename Arg2 = Arg1>
 struct minus : public detail::binary_function<Arg1, Arg2, Ret> {
-  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs)
+  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs) const
   {
     return Ret{lhs} - rhs;
   }
@@ -278,7 +278,7 @@ struct minus : public detail::binary_function<Arg1, Arg2, Ret> {
 template <typename Ret, typename Arg1 = Ret, typename Arg2 = Arg1>
 struct multiplies : public detail::binary_function<Arg1, Arg2, Ret>,
                     detail::associative_tag {
-  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs)
+  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs) const
   {
     return Ret{lhs} * rhs;
   }
@@ -287,7 +287,7 @@ struct multiplies : public detail::binary_function<Arg1, Arg2, Ret>,
 
 template <typename Ret, typename Arg1 = Ret, typename Arg2 = Arg1>
 struct divides : public detail::binary_function<Arg1, Arg2, Ret> {
-  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs)
+  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs) const
   {
     return Ret{lhs} / rhs;
   }
@@ -295,7 +295,7 @@ struct divides : public detail::binary_function<Arg1, Arg2, Ret> {
 
 template <typename Ret, typename Arg1 = Ret, typename Arg2 = Arg1>
 struct modulus : public detail::binary_function<Arg1, Arg2, Ret> {
-  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs)
+  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs) const
   {
     return Ret{lhs} % rhs;
   }
@@ -306,7 +306,7 @@ struct modulus : public detail::binary_function<Arg1, Arg2, Ret> {
 template <typename Arg1, typename Arg2 = Arg1>
 struct logical_and : public detail::comparison_function<Arg1, Arg2>,
                      detail::associative_tag {
-  RAJA_HOST_DEVICE bool operator()(const Arg1& lhs, const Arg2& rhs)
+  RAJA_HOST_DEVICE bool operator()(const Arg1& lhs, const Arg2& rhs) const
   {
     return lhs && rhs;
   }
@@ -316,7 +316,7 @@ struct logical_and : public detail::comparison_function<Arg1, Arg2>,
 template <typename Arg1, typename Arg2 = Arg1>
 struct logical_or : public detail::comparison_function<Arg1, Arg2>,
                     detail::associative_tag {
-  RAJA_HOST_DEVICE bool operator()(const Arg1& lhs, const Arg2& rhs)
+  RAJA_HOST_DEVICE bool operator()(const Arg1& lhs, const Arg2& rhs) const
   {
     return lhs || rhs;
   }
@@ -325,14 +325,14 @@ struct logical_or : public detail::comparison_function<Arg1, Arg2>,
 
 template <typename T>
 struct logical_not : public detail::unary_function<T, bool> {
-  RAJA_HOST_DEVICE bool operator()(const T& lhs) { return !lhs; }
+  RAJA_HOST_DEVICE bool operator()(const T& lhs) const { return !lhs; }
 };
 
 // Bitwise
 
 template <typename Ret, typename Arg1 = Ret, typename Arg2 = Arg1>
 struct bit_or : public detail::binary_function<Arg1, Arg2, Ret> {
-  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs)
+  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs) const
   {
     return lhs | rhs;
   }
@@ -340,7 +340,7 @@ struct bit_or : public detail::binary_function<Arg1, Arg2, Ret> {
 
 template <typename Ret, typename Arg1 = Ret, typename Arg2 = Arg1>
 struct bit_and : public detail::binary_function<Arg1, Arg2, Ret> {
-  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs)
+  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs) const
   {
     return lhs & rhs;
   }
@@ -348,7 +348,7 @@ struct bit_and : public detail::binary_function<Arg1, Arg2, Ret> {
 
 template <typename Ret, typename Arg1 = Ret, typename Arg2 = Arg1>
 struct bit_xor : public detail::binary_function<Arg1, Arg2, Ret> {
-  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs)
+  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs) const
   {
     return lhs ^ rhs;
   }
@@ -359,7 +359,7 @@ struct bit_xor : public detail::binary_function<Arg1, Arg2, Ret> {
 template <typename Ret, typename Arg1 = Ret, typename Arg2 = Arg1>
 struct minimum : public detail::binary_function<Arg1, Arg2, Ret>,
                  detail::associative_tag {
-  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs)
+  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs) const
   {
     return (lhs < rhs) ? lhs : rhs;
   }
@@ -369,7 +369,7 @@ struct minimum : public detail::binary_function<Arg1, Arg2, Ret>,
 template <typename Ret, typename Arg1 = Ret, typename Arg2 = Arg1>
 struct maximum : public detail::binary_function<Arg1, Arg2, Ret>,
                  detail::associative_tag {
-  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs)
+  RAJA_HOST_DEVICE Ret operator()(const Arg1& lhs, const Arg2& rhs) const
   {
     return (lhs < rhs) ? rhs : lhs;
   }
@@ -380,7 +380,7 @@ struct maximum : public detail::binary_function<Arg1, Arg2, Ret>,
 
 template <typename Arg1, typename Arg2 = Arg1>
 struct equal_to : public detail::comparison_function<Arg1, Arg2> {
-  RAJA_HOST_DEVICE bool operator()(const Arg1& lhs, const Arg2& rhs)
+  RAJA_HOST_DEVICE bool operator()(const Arg1& lhs, const Arg2& rhs) const
   {
     return lhs == rhs;
   }
@@ -388,7 +388,7 @@ struct equal_to : public detail::comparison_function<Arg1, Arg2> {
 
 template <typename Arg1, typename Arg2 = Arg1>
 struct not_equal_to : public detail::comparison_function<Arg1, Arg2> {
-  RAJA_HOST_DEVICE bool operator()(const Arg1& lhs, const Arg2& rhs)
+  RAJA_HOST_DEVICE bool operator()(const Arg1& lhs, const Arg2& rhs) const
   {
     return lhs != rhs;
   }
@@ -396,7 +396,7 @@ struct not_equal_to : public detail::comparison_function<Arg1, Arg2> {
 
 template <typename Arg1, typename Arg2 = Arg1>
 struct greater : public detail::comparison_function<Arg1, Arg2> {
-  RAJA_HOST_DEVICE bool operator()(const Arg1& lhs, const Arg2& rhs)
+  RAJA_HOST_DEVICE bool operator()(const Arg1& lhs, const Arg2& rhs) const
   {
     return lhs >= rhs;
   }
@@ -404,7 +404,7 @@ struct greater : public detail::comparison_function<Arg1, Arg2> {
 
 template <typename Arg1, typename Arg2 = Arg1>
 struct less : public detail::comparison_function<Arg1, Arg2> {
-  RAJA_HOST_DEVICE bool operator()(const Arg1& lhs, const Arg2& rhs)
+  RAJA_HOST_DEVICE bool operator()(const Arg1& lhs, const Arg2& rhs) const
   {
     return lhs <= rhs;
   }
@@ -413,7 +413,7 @@ struct less : public detail::comparison_function<Arg1, Arg2> {
 
 template <typename Arg1, typename Arg2 = Arg1>
 struct greater_equal : public detail::comparison_function<Arg1, Arg2> {
-  RAJA_HOST_DEVICE bool operator()(const Arg1& lhs, const Arg2& rhs)
+  RAJA_HOST_DEVICE bool operator()(const Arg1& lhs, const Arg2& rhs) const
   {
     return lhs >= rhs;
   }
@@ -421,7 +421,7 @@ struct greater_equal : public detail::comparison_function<Arg1, Arg2> {
 
 template <typename Arg1, typename Arg2 = Arg1>
 struct less_equal : public detail::comparison_function<Arg1, Arg2> {
-  RAJA_HOST_DEVICE bool operator()(const Arg1& lhs, const Arg2& rhs)
+  RAJA_HOST_DEVICE bool operator()(const Arg1& lhs, const Arg2& rhs) const
   {
     return lhs <= rhs;
   }
@@ -431,17 +431,17 @@ struct less_equal : public detail::comparison_function<Arg1, Arg2> {
 
 template <typename Ret, typename Orig = Ret>
 struct identity : public detail::unary_function<Orig, Ret> {
-  RAJA_HOST_DEVICE Ret operator()(const Orig& lhs) { return lhs; }
+  RAJA_HOST_DEVICE Ret operator()(const Orig& lhs) const { return lhs; } 
 };
 
 template <typename T, typename U>
 struct project1st : public detail::binary_function<T, U, T> {
-  RAJA_HOST_DEVICE T operator()(const T& lhs, const U& RAJA_UNUSED_ARG(rhs)) { return lhs; }
+  RAJA_HOST_DEVICE T operator()(const T& lhs, const U& RAJA_UNUSED_ARG(rhs)) const { return lhs; }
 };
 
 template <typename T, typename U = T>
 struct project2nd : public detail::binary_function<T, U, U> {
-  RAJA_HOST_DEVICE U operator()(const T& RAJA_UNUSED_ARG(lhs), const U& rhs) { return rhs; }
+  RAJA_HOST_DEVICE U operator()(const T& RAJA_UNUSED_ARG(lhs), const U& rhs) const { return rhs; }
 };
 
 // Type Traits

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,10 @@
 # 
 ###############################################################################
 
+if (RAJA_ENABLE_AGENCY)
+  include_directories(SYSTEM "${PROJECT_SOURCE_DIR}/extra/agency")
+endif()
+
 set (raja_sources 
   AlignedRangeIndexSetBuilders.cxx
   DepGraphNode.cxx

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,4 +43,8 @@
 
 include_directories(include)
 
+if (RAJA_ENABLE_AGENCY)
+  include_directories(SYSTEM "${PROJECT_SOURCE_DIR}/extra/agency")
+endif()
+
 add_subdirectory(unit)

--- a/test/unit/cpu/test-scan.cxx
+++ b/test/unit/cpu/test-scan.cxx
@@ -20,11 +20,18 @@ const int N = 1024;
 
 // Unit Test Space Exploration
 
+using ExecTypes = std::tuple<
+    RAJA::seq_exec
 #ifdef RAJA_ENABLE_OPENMP
-using ExecTypes = std::tuple<RAJA::seq_exec, RAJA::omp_parallel_for_exec>;
-#else
-using ExecTypes = std::tuple<RAJA::seq_exec>;
+    , RAJA::omp_parallel_for_exec
 #endif
+#ifdef RAJA_ENABLE_AGENCY
+    , RAJA::agency_parallel_exec
+#ifdef RAJA_ENABLE_OPENMP
+    , RAJA::agency_omp_parallel_exec
+#endif
+#endif
+>;
 
 using ReduceTypes = std::tuple<RAJA::operators::safe_plus<int>,
                                RAJA::operators::safe_plus<float>,
@@ -49,7 +56,7 @@ struct ForTesting {
 
 template <typename... Ts>
 struct ForTesting<std::tuple<Ts...>> {
-  using type = testing::Types<Ts...>;
+  using type = ::testing::Types<Ts...>;
 };
 
 using CrossTypes = ForTesting<Types>::type;

--- a/test/unit/gpu/CMakeLists.txt
+++ b/test/unit/gpu/CMakeLists.txt
@@ -45,6 +45,10 @@ if (NOT RAJA_ENABLE_NESTED)
   add_definitions(-DRAJA_ENABLE_NESTED)
 endif()
 
+if (RAJA_ENABLE_AGENCY)
+  include_directories(SYSTEM "${PROJECT_SOURCE_DIR}/extra/agency")
+endif()
+
 SET(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS)
 
 raja_add_test(


### PR DESCRIPTION
This adds the scan operation using Agency. It's heavily based on the OpenMP version, but only works on parallel Agency policies; given the way Agency is setup it requires the use of concurrent agents and executors, which would be unexpected given a sequential policy. Also modified the tests to handle more cases, however the simple version doesn't work when you add more policies (exceeds the max number of template arguments), but the workaround slows down compile time drastically.