### PR TITLE
Use forall inside of forallN to avoid code duplication

### DIFF
--- a/include/RAJA/exec-agency/forallN_agency.hxx
+++ b/include/RAJA/exec-agency/forallN_agency.hxx
@@ -107,26 +107,18 @@ struct ForallN_Executor<ForallN_PolicyPair<agency_base<Agent, Worker>,
   template <typename BODY>
   RAJA_INLINE void operator()(BODY body) const
   {
-    int begin_i = iset_i.getBegin();
     int begin_j = iset_j.getBegin();
-    int end_i = iset_i.getEnd();
     int end_j = iset_j.getEnd();
 
     ForallN_PeelOuter<NextExec, BODY> outer(next_exec, body);
 
-    auto numThreads = getMaxReduceThreadsCPU();
-    auto tiles = agency::experimental::tile_evenly(
-        agency::experimental::interval(begin_i, end_i), numThreads);
-
-    agency::bulk_invoke(Worker{}(tiles.size()),
-                        [&](Agent& self) {
-                            for (Index_type i : tiles[self.index]) {
-                                for (Index_type j = begin_j; j < end_j; ++j) {
-                                    outer(i, j);
-                                }
-                            }
-                        });
-    }
+    forall<agency_base<Agent, Worker>>(iset_i,
+        [&](Index_type i) {
+            for (Index_type j = begin_j; j < end_j; ++j) {
+                outer(i, j);
+            }
+        });
+  }
 };
 
 template <typename Agent, typename  Worker, typename... PREST>
@@ -156,30 +148,22 @@ struct ForallN_Executor<ForallN_PolicyPair<agency_base<Agent, Worker>,
   template <typename BODY>
   RAJA_INLINE void operator()(BODY body) const
   {
-    int begin_i = iset_i.getBegin();
     int begin_j = iset_j.getBegin();
     int begin_k = iset_k.getBegin();
-    int end_i = iset_i.getEnd();
     int end_j = iset_j.getEnd();
     int end_k = iset_k.getEnd();
 
     ForallN_PeelOuter<NextExec, BODY> outer(next_exec, body);
 
-    auto numThreads = getMaxReduceThreadsCPU();
-    auto tiles = agency::experimental::tile_evenly(
-        agency::experimental::interval(begin_i, end_i), numThreads);
-
-    agency::bulk_invoke(Worker{}(tiles.size()),
-                        [&](Agent& self) {
-                            for (Index_type i : tiles[self.index]) {
-                                for (Index_type j = begin_j; j < end_j; ++j) {
-                                    for (Index_type k = begin_k; k < end_k; ++k) {
-                                        outer(i, j, k);
-                                    }
-                                }
-                            }
-                        });
-    }
+    forall<agency_base<Agent, Worker>>(iset_i,
+        [&](Index_type i) {
+            for (Index_type j = begin_j; j < end_j; ++j) {
+                for (Index_type k = begin_k; k < end_k; ++k) {
+                    outer(i, j, k);
+                }
+            }
+        });
+  }
 };
 
 /******************************************************************


### PR DESCRIPTION
The code inside of `forallN` was virtually identical to `forall`, so avoided the duplication.